### PR TITLE
Integrate oscm-cm-provisioning module with CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...80"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: no        # [yes :: must have a base report to post]
+  require_head: yes       # [yes :: must have a head report to post]
+  branches: null

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,6 @@ cache:
 
 script:
   - gradle build
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Build status
 
 [![Build status](https://travis-ci.org/servicecatalog/oscm-cm-provisioning.svg?branch=master)](https://travis-ci.org/servicecatalog/oscm-cm-provisioning)
+[![codecov](https://codecov.io/gh/servicecatalog/oscm-cm-provisioning/branch/master/graph/badge.svg)](https://codecov.io/gh/servicecatalog/oscm-cm-provisioning)
 
 ## Running the application
 

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
 }
 
 apply plugin: 'java'
+apply plugin: 'jacoco'
 apply plugin: 'eclipse'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'io.spring.dependency-management'
@@ -36,3 +37,14 @@ dependencies {
 
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+
+jacocoTestReport {
+	reports {
+		xml.enabled true
+		html.enabled false
+		csv.enabled false
+	}
+}
+
+check.dependsOn jacocoTestReport
+test.finalizedBy jacocoTestReport


### PR DESCRIPTION
I have implemented the integration with CodeCov tool the same way as I did with oscm-cm-api. 
See: https://github.com/servicecatalog/oscm-cm-api/pull/11
